### PR TITLE
Make weighing process twice as fast

### DIFF
--- a/wii-scale/wii-scale.cpp
+++ b/wii-scale/wii-scale.cpp
@@ -53,9 +53,9 @@ void send_weight(std::deque<uint32_t> *totals, double calibrate)
     static std::chrono::high_resolution_clock::time_point lastTime;
     std::chrono::milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - lastTime);
 
-    if(ms.count() < 100)
+    if(ms.count() < 50)
     {
-        // Only send the weight every 0.1 of a second
+        // Only send the weight every 50 milliseconds
         return;
     }
 


### PR DESCRIPTION
The back end waits for 100 milliseconds between sending readings so
that it doesn't overwhelm the front-end with readings and complete the
weighing process too quickly.  However, 100ms * 50 readings = 5 seconds
which is a fair bit slower than the 3 seconds mentioned in the README.

To align the weighing speed with the user's expectations from the
README, halve the wait between sending readings to 50ms so that the
overall process takes 2.5s.